### PR TITLE
Use new (correct) package for CombinationMode

### DIFF
--- a/src/main/java/com/havingfunrightnow/kubejsminestuck/CombinationRecipeJS.java
+++ b/src/main/java/com/havingfunrightnow/kubejsminestuck/CombinationRecipeJS.java
@@ -1,6 +1,6 @@
 package com.havingfunrightnow.kubejsminestuck;
 
-import com.mraof.minestuck.alchemy.CombinationMode;
+import com.mraof.minestuck.alchemy.recipe.CombinationMode;
 import dev.latvian.mods.kubejs.recipe.*;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.crafting.Ingredient;


### PR DESCRIPTION
Currently, KJS fails to parse any combination recipe or create new ones because of a `java.lang.NoClassDefFoundError: com/mraof/minestuck/alchemy/CombinationMode`. This is a quick patch to fix that.